### PR TITLE
Kick off rules_ty project — design docs and architectural decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,10 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local worktrees for reference repos
+.worktrees/
+
+# Agents and MCP servers
+.tmp_wiki_content
+mcp-server.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,4 @@ Follow the PR checklist in [design/conventions.md](design/conventions.md) (secti
 ## 5. Key References
 
 - **Conventions and standards:** [design/conventions.md](design/conventions.md)
+- **External knowledge (Bazel, ty, rules_mypy):** [design/reference.md](design/reference.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,15 @@ rules_ty/
   plans/                 ← Proposals and ideations (frozen after implementation)
   design/
     conventions.md       ← Development conventions, coding standards, plan lifecycle
-    architecture.md      ← How the aspect works, module layout, key decisions (TBD)
-    reference.md         ← External knowledge: ty CLI, Bazel aspects, rules_mypy lessons (TBD)
+    architecture.md      ← UX decisions and internal architecture
+    reference.md         ← External knowledge: Bazel, ty, rules_multitool, integration testing
+  MODULE.bazel           ← Bazel module definition
+  REPO.bazel             ← ignore_directories() for non-Bazel dirs
+  .bazelrc               ← Default flags + --deleted_packages for examples
   ty/                    ← Bazel rules source code
-  examples/              ← Example usage of the rules
+  examples/              ← Integration test workspaces (each with own MODULE.bazel)
   docs/                  ← User-facing documentation (Sphinx / readthedocs)
+  .worktrees/            ← Cloned reference repos and worktrees (gitignored)
 ```
 
 ## 4. Before Creating a PR
@@ -35,4 +39,5 @@ Follow the PR checklist in [design/conventions.md](design/conventions.md) (secti
 ## 5. Key References
 
 - **Conventions and standards:** [design/conventions.md](design/conventions.md)
+- **Architecture and UX decisions:** [design/architecture.md](design/architecture.md)
 - **External knowledge (Bazel, ty, rules_mypy):** [design/reference.md](design/reference.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# rules_ty — Agent Guide
+
+## 1. Project
+
+Bazel rules for [ty](https://docs.astral.sh/ty/), the fast Python type checker by Astral.
+Similar to [rules_mypy](https://github.com/bazel-contrib/rules_mypy) but targeting ty, Bazel 9+, and fixing known pain points.
+
+GitHub: https://github.com/shayanhoshyari/rules_ty
+
+## 2. The Sync Contract
+
+`design/` is the source of truth. Source code is derived from it. Always update `design/` first, then code.
+
+Full details in [design/conventions.md](design/conventions.md) (section 4).
+
+## 3. Directory Layout
+
+```
+rules_ty/
+  AGENTS.md              ← You are here. Workflow and pointers.
+  plans/                 ← Proposals and ideations (frozen after implementation)
+  design/
+    conventions.md       ← Development conventions, coding standards, plan lifecycle
+    architecture.md      ← How the aspect works, module layout, key decisions (TBD)
+    reference.md         ← External knowledge: ty CLI, Bazel aspects, rules_mypy lessons (TBD)
+  ty/                    ← Bazel rules source code
+  examples/              ← Example usage of the rules
+  docs/                  ← User-facing documentation (Sphinx / readthedocs)
+```
+
+## 4. Before Creating a PR
+
+Follow the PR checklist in [design/conventions.md](design/conventions.md) (section 7).
+
+## 5. Key References
+
+- **Conventions and standards:** [design/conventions.md](design/conventions.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ rules_ty/
 
 ## 4. Before Creating a PR
 
-Follow the PR checklist in [design/conventions.md](design/conventions.md) (section 7).
+Follow the PR checklist in [design/conventions.md](design/conventions.md) (section 8).
 
 ## 5. Key References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See @AGENTS.md

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -1,0 +1,11 @@
+# Architecture
+
+How users interact with rules_ty and how it works internally. Covers both UX decisions and implementation details.
+
+## 1. User-Facing Behavior
+
+### 1.1 Always-on by default
+
+Type checking is always enabled. There is no opt-in mode (no `opt_in_tags`). Users who want to skip specific targets can use suppression tags (e.g., `tags = ["no-ty"]`).
+
+Rationale: opt-in mode in rules_mypy was useful for gradual adoption in existing codebases, but adds complexity. For rules_ty, the expectation is that users enable it project-wide. Skipping individual targets via tags covers the escape hatch.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -9,3 +9,36 @@ How users interact with rules_ty and how it works internally. Covers both UX dec
 Type checking is always enabled. There is no opt-in mode (no `opt_in_tags`). Users who want to skip specific targets can use suppression tags (e.g., `tags = ["no-ty"]`).
 
 Rationale: opt-in mode in rules_mypy was useful for gradual adoption in existing codebases, but adds complexity. For rules_ty, the expectation is that users enable it project-wide. Skipping individual targets via tags covers the escape hatch.
+
+### 1.2 Requires venvs_site_packages
+
+rules_ty only supports projects with `--@rules_python//python/config_settings:venvs_site_packages=yes` enabled. This is the modern rules_python mode where each py_binary gets a proper `.venv/site-packages/` layout with symlinks.
+
+Rationale:
+- **Simpler module resolution.** ty natively discovers packages in standard venv layouts. Requiring venvs_site_packages means we can leverage this instead of manually constructing search paths from runfiles (the most complex and fragile part of rules_mypy).
+- **Future-looking.** venvs_site_packages is the direction rules_python is heading. Building on the old `sys.path`-based layout would mean supporting a mode that is likely to be superseded.
+- **Better third-party compatibility.** Packages like torch, nvidia CUDA libs, and others that assume site-packages layout work correctly with this mode.
+
+The exact mechanism (how the aspect uses the venv layout or `PyInfo.venv_symlinks` provider) will be determined during the PoC ([Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2)).
+
+## 2. Key Design Decisions
+
+### 2.1 No cache propagation (assumption — needs PoC validation)
+
+ty is reported as 10-100x faster than mypy. The working assumption is that this eliminates the need for the `MypyCacheInfo` provider and inter-target cache merging that rules_mypy uses.
+
+However, in Bazel each target runs ty independently. If many targets depend on a large package (e.g., torch), ty would analyze that package once per target. Even at 10x mypy's speed, this could add up. The PoC ([Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2)) must measure per-target times with large transitive deps to validate this assumption. If it doesn't hold, we may need to revisit caching.
+
+### 2.2 No types mapping
+
+rules_mypy requires a `types` dict mapping deps to their stub packages. We drop this and rely on gazelle's `python_generate_pyi_deps` to add stub deps to the dependency graph automatically. ty finds them via `--extra-search-path`.
+
+### 2.3 Python version from toolchain
+
+rules_mypy requires `python_version` as a parameter on `mypy_cli`. We infer it from the Python toolchain (`ctx.toolchains`) and pass `--python-version` to ty automatically.
+
+## 3. Open Risk: Module Resolution in Sandbox
+
+ty discovers packages via virtual environments or `python` on PATH. In a Bazel sandbox, neither exists. The plan is to use `--extra-search-path` pointing at runfiles directories (same strategy as rules_mypy's `MYPYPATH`).
+
+This needs validation: [Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2) — proof-of-concept to verify ty's module resolution works with Bazel's runfiles layout for first-party, third-party, and stub packages.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -12,14 +12,18 @@ Rationale: opt-in mode in rules_mypy was useful for gradual adoption in existing
 
 ### 1.2 Requires venvs_site_packages
 
-rules_ty only supports projects with `--@rules_python//python/config_settings:venvs_site_packages=yes` enabled. This is the modern rules_python mode where each py_binary gets a proper `.venv/site-packages/` layout with symlinks.
+rules_ty only supports projects with `--@rules_python//python/config_settings:venvs_site_packages=yes` enabled. This is the modern rules_python mode where each `py_binary` gets a proper `.venv/site-packages/` layout with symlinks.
 
-Rationale:
-- **Simpler module resolution.** ty natively discovers packages in standard venv layouts. Requiring venvs_site_packages means we can leverage this instead of manually constructing search paths from runfiles (the most complex and fragile part of rules_mypy).
+**Important:** `venvs_site_packages` only affects third-party packages pulled in via pip. First-party `py_library` sources remain in the runfiles tree and are not placed in site-packages. This means module resolution has two paths:
+- **Third-party (pip) deps:** ty discovers them via the venv `site-packages/` layout.
+- **First-party `py_library` deps:** the aspect must use `--extra-search-path` (or `--python`) to point ty at runfiles directories, similar to how rules_mypy sets `MYPYPATH`.
+
+Rationale for requiring the feature despite only covering third-party:
+- **Simplifies the harder problem.** Third-party resolution was the most complex and fragile part of rules_mypy (constructing MYPYPATH for all transitive pip deps). venvs_site_packages eliminates this entirely.
 - **Future-looking.** venvs_site_packages is the direction rules_python is heading. Building on the old `sys.path`-based layout would mean supporting a mode that is likely to be superseded.
 - **Better third-party compatibility.** Packages like torch, nvidia CUDA libs, and others that assume site-packages layout work correctly with this mode.
 
-The exact mechanism (how the aspect uses the venv layout or `PyInfo.venv_symlinks` provider) will be determined during the PoC ([Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2)).
+The exact mechanism (how the aspect wires up both paths) will be determined during the PoC ([Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2)).
 
 ## 2. Key Design Decisions
 
@@ -27,7 +31,16 @@ The exact mechanism (how the aspect uses the venv layout or `PyInfo.venv_symlink
 
 ty is reported as 10-100x faster than mypy. The working assumption is that this eliminates the need for the `MypyCacheInfo` provider and inter-target cache merging that rules_mypy uses.
 
-However, in Bazel each target runs ty independently. If many targets depend on a large package (e.g., torch), ty would analyze that package once per target. Even at 10x mypy's speed, this could add up. The PoC ([Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2)) must measure per-target times with large transitive deps to validate this assumption. If it doesn't hold, we may need to revisit caching.
+However, in Bazel each target runs ty independently. If many targets depend on a large package (e.g., torch), ty would analyze that package once per target. Even at 10x mypy's speed, this could add up.
+
+**Success criterion:** any single `py_library` target must complete `ty check` in under 1 second, regardless of its position in the dependency graph. If it doesn't, we need to revisit caching.
+
+The PoC ([Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2)) must measure these scenarios:
+1. **Massive third-party dep** — `py_library` with 1 source file importing torch.
+2. **Multiple heavy third-party deps** — `py_library` importing pandas + numpy.
+3. **Deep first-party chain** — `py_library` at the bottom of ~20+ transitive `py_library` deps, each with a few files.
+4. **Wide third-party imports** — `py_library` importing 10-15 different third-party packages.
+5. **Leaf library (baseline)** — small `py_library` near the top of the chain with few deps. Should be fast; if not, something is fundamentally wrong.
 
 ### 2.2 No types mapping
 
@@ -39,6 +52,12 @@ rules_mypy requires `python_version` as a parameter on `mypy_cli`. We infer it f
 
 ## 3. Open Risk: Module Resolution in Sandbox
 
-ty discovers packages via virtual environments or `python` on PATH. In a Bazel sandbox, neither exists. The plan is to use `--extra-search-path` pointing at runfiles directories (same strategy as rules_mypy's `MYPYPATH`).
+ty discovers packages via virtual environments or `python` on PATH. In a Bazel sandbox, neither exists natively. Our strategy uses two complementary mechanisms:
 
-This needs validation: [Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2) — proof-of-concept to verify ty's module resolution works with Bazel's runfiles layout for first-party, third-party, and stub packages.
+- **Third-party (pip) deps:** `venvs_site_packages` creates a `.venv/site-packages/` layout. ty can discover these via `--python` pointing at the venv, or `VIRTUAL_ENV`.
+- **First-party `py_library` deps:** sources live in the runfiles tree. The aspect must pass their paths via `--extra-search-path`, similar to rules_mypy's `MYPYPATH`.
+
+Both paths need PoC validation in [Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2):
+- Can ty use the venv created by `venvs_site_packages` for third-party discovery?
+- Does `--extra-search-path` work for first-party modules in the runfiles layout?
+- Do stubs (`.pyi`) resolve correctly through both paths?

--- a/design/conventions.md
+++ b/design/conventions.md
@@ -13,6 +13,7 @@
 | `ty/` | Bazel rules source code | Derived from `design/` |
 | `examples/` | Example usage of the rules | Updated alongside `ty/` |
 | `docs/` | User-facing documentation (Sphinx / readthedocs) | Updated alongside `design/` |
+| `.worktrees/` | Cloned external repos for reference (e.g. foundry, rules_mypy). Gitignored. | Agent-managed, not committed |
 
 ## 3. Plan Lifecycle
 

--- a/design/conventions.md
+++ b/design/conventions.md
@@ -4,6 +4,8 @@
 
 `AGENTS.md` is the compact entry point that summarizes the project and points to `design/` files. Documents in `design/` must be **standalone** -- they should not reference back to `AGENTS.md` for their content. If both files need the same information, the full version lives in `design/` and `AGENTS.md` contains a short summary with a pointer.
 
+`design/architecture.md` covers both UX decisions and internal architecture in a single file. The boundary between "how users use it" and "how it works" is blurry for a Bazel ruleset. Split if the file grows unwieldy.
+
 ## 2. Folder Roles
 
 | Folder | Role | Mutability |
@@ -73,8 +75,10 @@ This is an **AI-native development** project. `design/` is the source of truth. 
 
 ### Testing
 
-- Integration tests using Bazel's test infrastructure.
-- Example projects in `examples/` double as smoke tests.
+- All sanity checks must be `bazel test` targets. The agent should be able to run `bazel test //...` and get a pass/fail on everything — no manual steps.
+- Integration tests via `rules_bazel_integration_test` on example workspaces.
+- Formatting checks (buildifier) as test targets.
+- `--deleted_packages` sync check as a test target.
 
 ## 6. Dependency Updates
 

--- a/design/conventions.md
+++ b/design/conventions.md
@@ -76,12 +76,18 @@ This is an **AI-native development** project. `design/` is the source of truth. 
 - Integration tests using Bazel's test infrastructure.
 - Example projects in `examples/` double as smoke tests.
 
-## 6. Commit Conventions
+## 6. Dependency Updates
+
+Keep dependencies current. For now there is no fixed cadence — the human decides when to update. As the project matures, this may be automated with renovate or dependabot.
+
+See [design/reference.md](reference.md) (section 4) for the actual update procedures.
+
+## 7. Commit Conventions
 
 - Commit messages should be concise and focus on *why*, not *what*.
 - If a commit touches both `design/` and source code, lead with the design change in the message.
 
-## 7. PR Checklist
+## 8. PR Checklist
 
 Before creating a PR, verify all of the following:
 

--- a/design/conventions.md
+++ b/design/conventions.md
@@ -1,0 +1,103 @@
+# Development Conventions
+
+## 1. Document Structure
+
+`AGENTS.md` is the compact entry point that summarizes the project and points to `design/` files. Documents in `design/` must be **standalone** -- they should not reference back to `AGENTS.md` for their content. If both files need the same information, the full version lives in `design/` and `AGENTS.md` contains a short summary with a pointer.
+
+## 2. Folder Roles
+
+| Folder | Role | Mutability |
+|--------|------|------------|
+| `plans/` | Proposals, ideations, brainstorming | Frozen after implementation |
+| `design/` | Living specs — architecture, conventions, reference | Updated as the project evolves |
+| `ty/` | Bazel rules source code | Derived from `design/` |
+| `examples/` | Example usage of the rules | Updated alongside `ty/` |
+| `docs/` | User-facing documentation (Sphinx / readthedocs) | Updated alongside `design/` |
+
+## 3. Plan Lifecycle
+
+Plans are the equivalent of RFCs or ADRs (Architecture Decision Records).
+
+### Creating a plan
+
+- One plan per effort, named `plans/issueN-short-description.md`.
+- A plan starts as a brainstorm: context, options, open questions.
+- The human and agent collaborate on the plan until decisions are made.
+
+### Implementing a plan
+
+1. Update `design/` files with the outcomes from the plan.
+2. Update source code to match `design/`.
+3. Mark completed items in the plan with checkmarks.
+
+### Freezing a plan
+
+Once fully implemented, add a status header at the top of the plan:
+
+```
+Status: Implemented
+Landed in: design/architecture.md (section X), design/conventions.md (section Y)
+```
+
+A frozen plan is never edited again. If something changes later, that's a new plan that references the old one.
+
+### Why keep frozen plans?
+
+`design/` says *what* the current state is. Plans say *why* we chose it over alternatives. They're the decision log.
+
+## 4. The Sync Contract
+
+This is an **AI-native development** project. `design/` is the source of truth. Source code is derived from it.
+
+**Order of operations for every change:**
+
+1. Identify which `design/` file(s) are affected.
+2. Update `design/` first with the new behavior/spec.
+3. Then update source code to implement what `design/` now says.
+4. If a change is purely internal (refactor, bug fix, no behavior change), code-only changes are OK — but explain why no design change was needed.
+
+## 5. Coding Standards
+
+### Starlark / Bazel
+
+- Target Bazel 9+ only. No WORKSPACE support — bzlmod only.
+- Use `aspect()` for the type-checking integration, following the pattern from rules_mypy.
+- Private implementation files go in `ty/private/`. Public API in `ty/ty.bzl`.
+- Use `buildifier` for formatting.
+
+### Python (tooling, runners)
+
+- Use type hints.
+- Format with `ruff`.
+
+### Testing
+
+- Integration tests using Bazel's test infrastructure.
+- Example projects in `examples/` double as smoke tests.
+
+## 6. Commit Conventions
+
+- Commit messages should be concise and focus on *why*, not *what*.
+- If a commit touches both `design/` and source code, lead with the design change in the message.
+
+## 7. PR Checklist
+
+Before creating a PR, verify all of the following:
+
+### Design ↔ Code sync
+- [ ] If source code changed, are the corresponding `design/` files up to date?
+- [ ] If `design/` files changed, does the source code match?
+
+### Conventions
+- [ ] New conventions are in `design/conventions.md`, not scattered in code comments, commit messages, or other docs.
+
+### Plans
+- [ ] Implemented plans have a frozen status header (`Status: Implemented`, `Landed in: ...`).
+- [ ] No edits to already-frozen plans. If something changes, create a new plan that references the old one.
+
+### Cross-references
+- [ ] All file references in `AGENTS.md` and `design/` files point to files that exist.
+
+### Tests
+- [ ] Existing tests still pass.
+- [ ] New functionality has test coverage (integration tests or examples).

--- a/design/conventions.md
+++ b/design/conventions.md
@@ -13,7 +13,7 @@
 | `ty/` | Bazel rules source code | Derived from `design/` |
 | `examples/` | Example usage of the rules | Updated alongside `ty/` |
 | `docs/` | User-facing documentation (Sphinx / readthedocs) | Updated alongside `design/` |
-| `.worktrees/` | Cloned external repos for reference (e.g. foundry, rules_mypy). Gitignored. | Agent-managed, not committed |
+| `.worktrees/` | Cloned external repos for reference and git worktrees of this repo. Gitignored. | Agent-managed, not committed |
 
 ## 3. Plan Lifecycle
 

--- a/design/reference.md
+++ b/design/reference.md
@@ -17,7 +17,21 @@ ignore_directories(["plans", "design", "docs", ".worktrees"])
 
 Reference: https://bazel.build/rules/lib/globals/repo
 
-### 1.2 No WORKSPACE
+### 1.2 ignore_directories() vs --deleted_packages
+
+Two mechanisms for hiding directories from Bazel, used for different purposes:
+
+- **`ignore_directories()`** (REPO.bazel): Makes directories completely invisible to Bazel. `glob()` cannot see files inside, labels cannot reference them. Use for non-Bazel directories.
+- **`--deleted_packages`** (.bazelrc): Removes specific packages from the parent's package tree, but files remain visible to `glob()`. Use for child workspaces whose BUILD files would conflict with the parent, but whose files need to be passed to integration tests.
+
+```
+# .bazelrc — auto-populated by:
+# bazel run @rules_bazel_integration_test//tools:update_deleted_packages
+build --deleted_packages=examples/simple,examples/comprehensive
+query --deleted_packages=examples/simple,examples/comprehensive
+```
+
+### 1.3 No WORKSPACE
 
 Bazel 9+ uses bzlmod exclusively. Do not create `WORKSPACE` or `WORKSPACE.bazel` files. Use `MODULE.bazel` for all dependency management.
 
@@ -130,9 +144,81 @@ Reference: https://github.com/theoremlp/multitool
 
 Once the project matures, set up renovate or dependabot to automate the above. Renovate supports both Bazel MODULE.bazel and custom lockfile patterns.
 
-## 5. rules_mypy (prior art)
+## 5. rules_bazel_integration_test
 
-### 5.1 Architecture
+We use `rules_bazel_integration_test` to test examples against multiple Bazel versions. Tests are regular `bazel test` targets — runnable locally, not just in CI.
+
+Reference: https://github.com/bazel-contrib/rules_bazel_integration_test
+
+### 5.1 Setup pattern
+
+In `MODULE.bazel`:
+```starlark
+bazel_dep(name = "rules_bazel_integration_test", version = "0.37.1", dev_dependency = True)
+
+bazel_binaries = use_extension(
+    "@rules_bazel_integration_test//:extensions.bzl",
+    "bazel_binaries",
+    dev_dependency = True,
+)
+bazel_binaries.download(version_file = "//:.bazelversion")
+bazel_binaries.download(version = "9.0.0")
+use_repo(bazel_binaries, "bazel_binaries")
+```
+
+In `examples/BUILD.bazel`:
+```starlark
+load("@bazel_binaries//:defs.bzl", "bazel_binaries")
+load("@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+     "bazel_integration_tests", "default_test_runner", "integration_test_utils")
+
+default_test_runner(name = "test_runner")
+
+bazel_integration_tests(
+    name = "basic_test",
+    bazel_binaries = bazel_binaries,
+    bazel_versions = bazel_binaries.versions.all,
+    test_runner = ":test_runner",
+    workspace_files = integration_test_utils.glob_workspace_files("basic") + [
+        "//:local_repository_files",
+    ],
+    workspace_path = "basic",
+)
+```
+
+### 5.2 Child workspace pattern
+
+Each example has its own `MODULE.bazel` referencing the parent via `local_path_override`:
+```starlark
+# examples/basic/MODULE.bazel
+bazel_dep(name = "rules_ty", version = "0.0.0")
+local_path_override(module_name = "rules_ty", path = "../..")
+```
+
+### 5.3 Parent workspace filegroup
+
+The root `BUILD.bazel` must expose parent files for child workspaces:
+```starlark
+filegroup(
+    name = "local_repository_files",
+    srcs = [
+        "BUILD.bazel",
+        "MODULE.bazel",
+        "//ty:all_files",
+        "//ty/private:all_files",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+```
+
+Each parent package needs an `all_files` filegroup:
+```starlark
+filegroup(name = "all_files", srcs = glob(["*"]), visibility = ["//:__subpackages__"])
+```
+
+## 6. rules_mypy (prior art)
+
+### 6.1 Architecture
 
 rules_mypy uses a Bazel aspect that:
 1. Attaches to `py_binary`, `py_library`, `py_test` targets
@@ -141,14 +227,14 @@ rules_mypy uses a Bazel aspect that:
 4. Runs mypy via a `py_binary` wrapper with `MYPYPATH` set to include all dependency paths
 5. Produces a cache directory as output for downstream targets
 
-### 5.2 Key patterns to reuse
+### 6.2 Key patterns to reuse
 
 - Aspect propagates along `deps` via `attr_aspects = ["deps"]`
 - Opt-in/opt-out via tags (`suppression_tags`, `opt_in_tags`)
 - External dep paths extracted from `PyInfo.imports`
 - Config file passed as a label attribute
 
-### 5.3 Key patterns to drop
+### 6.3 Key patterns to drop
 
 - Cache propagation (`MypyCacheInfo`) -- ty is fast enough
 - `py_binary` wrapper for the checker -- ty is a standalone binary

--- a/design/reference.md
+++ b/design/reference.md
@@ -122,7 +122,9 @@ In a Bazel sandbox, (1-3) don't exist. We rely on rules_python's `venvs_site_pac
 
 rules_ty requires `--@rules_python//python/config_settings:venvs_site_packages=yes`.
 
-When enabled, rules_python creates a per-binary `.venv/lib/pythonX.Y/site-packages/` with symlinks to packages in runfiles. This gives ty a standard venv layout for module discovery.
+When enabled, rules_python creates a per-binary `.venv/lib/pythonX.Y/site-packages/` with symlinks to packages in runfiles. This gives ty a standard venv layout for third-party module discovery.
+
+**Scope limitation:** this feature only affects third-party packages from pip. First-party `py_library` sources are not placed in site-packages — they remain in the runfiles tree and must be discovered via `--extra-search-path` or `PyInfo.imports`.
 
 **Enabling:**
 - Flag: `--@rules_python//python/config_settings:venvs_site_packages=yes`

--- a/design/reference.md
+++ b/design/reference.md
@@ -1,0 +1,75 @@
+# External Reference
+
+Knowledge about external tools and APIs that the agent needs during development. This file is the place to capture things the agent doesn't reliably know.
+
+## 1. Bazel 9+
+
+### 1.1 REPO.bazel and ignore_directories()
+
+Use `REPO.bazel` with `ignore_directories()` to exclude non-Bazel directories. This replaces the legacy `.bazelignore` file.
+
+```starlark
+# REPO.bazel
+ignore_directories(["plans", "design", "docs", ".worktrees"])
+```
+
+`ignore_directories()` takes a list of directory paths (relative to repo root) and supports glob patterns. Directories listed here are invisible to the build graph.
+
+Reference: https://bazel.build/rules/lib/globals/repo
+
+### 1.2 No WORKSPACE
+
+Bazel 9+ uses bzlmod exclusively. Do not create `WORKSPACE` or `WORKSPACE.bazel` files. Use `MODULE.bazel` for all dependency management.
+
+## 2. ty
+
+### 2.1 CLI basics
+
+ty is a standalone Rust binary (not a Python library). Key flags for Bazel integration:
+
+```
+ty check [PATH...]              # Check specific files
+  --extra-search-path PATH      # Additional module resolution path (repeatable)
+  --python-version VERSION      # Target Python version (3.7-3.15)
+  --python PATH                 # Path to Python environment or interpreter
+  --config-file PATH            # Path to ty.toml config
+  --output-format FORMAT        # full, concise, github, gitlab, junit
+  --project PATH                # Project directory
+  --exit-zero                   # Always exit 0 (useful for non-blocking checks)
+```
+
+Reference: https://docs.astral.sh/ty/reference/cli/
+
+### 2.2 Module resolution
+
+ty discovers installed packages via:
+1. Active virtual environment (`VIRTUAL_ENV`)
+2. `.venv` in project root
+3. `python3` or `python` on PATH
+
+In a Bazel sandbox, none of these exist. Use `--extra-search-path` to point at the runfiles tree, similar to how rules_mypy sets `MYPYPATH`.
+
+## 3. rules_mypy (prior art)
+
+### 3.1 Architecture
+
+rules_mypy uses a Bazel aspect that:
+1. Attaches to `py_binary`, `py_library`, `py_test` targets
+2. Skips non-root targets (`target.label.workspace_root != ""`)
+3. Collects source files, dependency paths, and upstream caches
+4. Runs mypy via a `py_binary` wrapper with `MYPYPATH` set to include all dependency paths
+5. Produces a cache directory as output for downstream targets
+
+### 3.2 Key patterns to reuse
+
+- Aspect propagates along `deps` via `attr_aspects = ["deps"]`
+- Opt-in/opt-out via tags (`suppression_tags`, `opt_in_tags`)
+- External dep paths extracted from `PyInfo.imports`
+- Config file passed as a label attribute
+
+### 3.3 Key patterns to drop
+
+- Cache propagation (`MypyCacheInfo`) -- ty is fast enough
+- `py_binary` wrapper for the checker -- ty is a standalone binary
+- `types` dict mapping deps to stub packages -- rely on gazelle instead
+- `python_version` on the CLI macro -- infer from toolchain

--- a/design/reference.md
+++ b/design/reference.md
@@ -21,9 +21,62 @@ Reference: https://bazel.build/rules/lib/globals/repo
 
 Bazel 9+ uses bzlmod exclusively. Do not create `WORKSPACE` or `WORKSPACE.bazel` files. Use `MODULE.bazel` for all dependency management.
 
-## 2. ty
+## 2. rules_multitool (binary resolution)
 
-### 2.1 CLI basics
+We use `rules_multitool` to download the ty binary per platform. This is the same approach rules_uv uses for uv.
+
+### 2.1 Setup pattern (from rules_uv)
+
+In `MODULE.bazel`:
+```starlark
+bazel_dep(name = "rules_multitool", version = "1.11.1")
+
+multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
+multitool.hub(lockfile = "//ty/private:ty.lock.json")
+use_repo(multitool, "multitool")
+```
+
+In rule attributes:
+```starlark
+"_ty": attr.label(default = "@multitool//tools/ty", executable = True, cfg = "exec"),
+```
+
+### 2.2 Lockfile format
+
+`ty/private/ty.lock.json` specifies per-platform binary URLs and SHAs:
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
+  "ty": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/astral-sh/ty/releases/download/<version>/ty-<platform>.tar.gz",
+        "file": "ty-<platform>/ty",
+        "sha256": "<hash>",
+        "os": "linux",
+        "cpu": "x86_64"
+      }
+    ]
+  }
+}
+```
+
+The `multitool` CLI can auto-update this lockfile.
+
+### 2.3 Why cfg = "exec" and not transition_to_target
+
+Our aspect runs ty via `ctx.actions.run()` — a build action that executes on the exec platform.
+`cfg = "exec"` downloads the correct binary for that platform. No transition hack needed.
+
+This differs from rules_uv's run rules which needed a `transition_to_target` workaround
+([PR #122](https://github.com/bazel-contrib/rules_uv/pull/122)).
+
+Reference: https://github.com/theoremlp/rules_multitool
+
+## 3. ty
+
+### 3.1 CLI basics
 
 ty is a standalone Rust binary (not a Python library). Key flags for Bazel integration:
 
@@ -40,7 +93,7 @@ ty check [PATH...]              # Check specific files
 
 Reference: https://docs.astral.sh/ty/reference/cli/
 
-### 2.2 Module resolution
+### 3.2 Module resolution
 
 ty discovers installed packages via:
 1. Active virtual environment (`VIRTUAL_ENV`)
@@ -49,9 +102,9 @@ ty discovers installed packages via:
 
 In a Bazel sandbox, none of these exist. Use `--extra-search-path` to point at the runfiles tree, similar to how rules_mypy sets `MYPYPATH`.
 
-## 3. rules_mypy (prior art)
+## 4. rules_mypy (prior art)
 
-### 3.1 Architecture
+### 4.1 Architecture
 
 rules_mypy uses a Bazel aspect that:
 1. Attaches to `py_binary`, `py_library`, `py_test` targets
@@ -60,14 +113,14 @@ rules_mypy uses a Bazel aspect that:
 4. Runs mypy via a `py_binary` wrapper with `MYPYPATH` set to include all dependency paths
 5. Produces a cache directory as output for downstream targets
 
-### 3.2 Key patterns to reuse
+### 4.2 Key patterns to reuse
 
 - Aspect propagates along `deps` via `attr_aspects = ["deps"]`
 - Opt-in/opt-out via tags (`suppression_tags`, `opt_in_tags`)
 - External dep paths extracted from `PyInfo.imports`
 - Config file passed as a label attribute
 
-### 3.3 Key patterns to drop
+### 4.3 Key patterns to drop
 
 - Cache propagation (`MypyCacheInfo`) -- ty is fast enough
 - `py_binary` wrapper for the checker -- ty is a standalone binary

--- a/design/reference.md
+++ b/design/reference.md
@@ -102,9 +102,37 @@ ty discovers installed packages via:
 
 In a Bazel sandbox, none of these exist. Use `--extra-search-path` to point at the runfiles tree, similar to how rules_mypy sets `MYPYPATH`.
 
-## 4. rules_mypy (prior art)
+## 4. Updating Dependencies
 
-### 4.1 Architecture
+### 4.1 ty binary (multitool lockfile)
+
+Update `ty/private/ty.lock.json` to the latest ty release:
+
+```bash
+# Install multitool CLI if not available
+cargo install multitool
+
+# Update the lockfile (fetches latest release, updates URLs and SHAs)
+multitool --lockfile ty/private/ty.lock.json update
+```
+
+Reference: https://github.com/theoremlp/multitool
+
+### 4.2 Bazel module deps (MODULE.bazel)
+
+`bazel_dep()` versions for rules_python, rules_multitool, bazel_skylib, etc. are pinned in `MODULE.bazel`. To update:
+
+1. Check for new versions on the [Bazel Central Registry](https://registry.bazel.build/).
+2. Update the version string in the `bazel_dep()` call.
+3. Run `bazel build //...` to verify compatibility.
+
+### 4.3 Automation (future)
+
+Once the project matures, set up renovate or dependabot to automate the above. Renovate supports both Bazel MODULE.bazel and custom lockfile patterns.
+
+## 5. rules_mypy (prior art)
+
+### 5.1 Architecture
 
 rules_mypy uses a Bazel aspect that:
 1. Attaches to `py_binary`, `py_library`, `py_test` targets
@@ -113,14 +141,14 @@ rules_mypy uses a Bazel aspect that:
 4. Runs mypy via a `py_binary` wrapper with `MYPYPATH` set to include all dependency paths
 5. Produces a cache directory as output for downstream targets
 
-### 4.2 Key patterns to reuse
+### 5.2 Key patterns to reuse
 
 - Aspect propagates along `deps` via `attr_aspects = ["deps"]`
 - Opt-in/opt-out via tags (`suppression_tags`, `opt_in_tags`)
 - External dep paths extracted from `PyInfo.imports`
 - Config file passed as a label attribute
 
-### 4.3 Key patterns to drop
+### 5.3 Key patterns to drop
 
 - Cache propagation (`MypyCacheInfo`) -- ty is fast enough
 - `py_binary` wrapper for the checker -- ty is a standalone binary

--- a/design/reference.md
+++ b/design/reference.md
@@ -113,8 +113,43 @@ ty discovers installed packages via:
 1. Active virtual environment (`VIRTUAL_ENV`)
 2. `.venv` in project root
 3. `python3` or `python` on PATH
+4. `--extra-search-path` for additional module resolution paths
+5. `--python` pointing to a Python interpreter or venv
 
-In a Bazel sandbox, none of these exist. Use `--extra-search-path` to point at the runfiles tree, similar to how rules_mypy sets `MYPYPATH`.
+In a Bazel sandbox, (1-3) don't exist. We rely on rules_python's `venvs_site_packages` mode to provide a proper venv layout (see section 3.3).
+
+### 3.3 rules_python venvs_site_packages
+
+rules_ty requires `--@rules_python//python/config_settings:venvs_site_packages=yes`.
+
+When enabled, rules_python creates a per-binary `.venv/lib/pythonX.Y/site-packages/` with symlinks to packages in runfiles. This gives ty a standard venv layout for module discovery.
+
+**Enabling:**
+- Flag: `--@rules_python//python/config_settings:venvs_site_packages=yes`
+- Default is `no`. Only affects PyPI dependencies of `--bootstrap_impl=script` binaries.
+- Requires `--@rules_python//python/config_settings:bootstrap_impl=script` (which requires rules_python toolchain, i.e. Bazel 7+ with bzlmod).
+
+**Provider API (`PyInfo.venv_symlinks`):**
+
+Added in rules_python 1.5.0. A depset of `VenvSymlinkEntry`, each with:
+- `kind`: one of `VenvSymlinkKind.LIB` (site-packages), `VenvSymlinkKind.BIN`, or `VenvSymlinkKind.INCLUDE`
+- `venv_path`: path relative to the kind directory in the venv
+- `link_to_path`: runfiles-root relative path that `venv_path` symlinks to (if `link_to_file` is None)
+- `link_to_file`: a File that `venv_path` should point to (added in 1.7.0)
+- `files`: depset of Files under `link_to_path`
+- `package`: normalized PyPI package name (added for overlap resolution)
+- `version`: PEP 440 normalized version
+
+Per-binary: each `py_binary` gets its own venv. `py_library` targets don't create a venv but carry the provider for downstream binaries.
+
+**Status:** still marked experimental as of rules_python 1.x (API may change). The provider evolved from `site_packages_symlinks` (tuples) to `venv_symlinks` (VenvSymlinkEntry). Known open issues exist (flask compat [#3056], overlapping action outputs [#3204]).
+
+**References:**
+- Config setting docs: https://rules-python.readthedocs.io/en/stable/api/rules_python/python/config_settings/index.html
+- PyInfo / VenvSymlinkEntry API: https://rules-python.readthedocs.io/en/latest/api/rules_python/python/private/py_info.html
+- Tracking issue: https://github.com/bazelbuild/rules_python/issues/2156
+- Initial PR: https://github.com/bazelbuild/rules_python/pull/2617
+- Known issues: https://github.com/bazel-contrib/rules_python/issues/3056, https://github.com/bazel-contrib/rules_python/issues/3204
 
 ## 4. Updating Dependencies
 

--- a/plans/issue1-kick-off.md
+++ b/plans/issue1-kick-off.md
@@ -175,13 +175,14 @@ All four issues from the GitHub issue are addressable:
 4. Remove `python_version` param → infer from Python toolchain
 
 **Key decision:** require `rules_python` `venvs_site_packages=yes`. This mode gives each
-`py_binary` a standard `.venv/site-packages/` layout, which ty natively discovers. This
-simplifies module resolution (no manual `--extra-search-path` per dep) and is future-looking
-(this is the direction rules_python is heading). See `design/architecture.md` §1.2.
+`py_binary` a standard `.venv/site-packages/` layout for third-party (pip) deps, which ty
+natively discovers. First-party `py_library` sources are not affected — they remain in the
+runfiles tree and need `--extra-search-path`. This is a two-path strategy: venv for
+third-party, extra-search-path for first-party. See `design/architecture.md` §1.2 and §3.
 
-**One concrete risk:** module resolution in the Bazel sandbox. Need to verify that ty can
-use the venv layout provided by `venvs_site_packages` for first-party, third-party, and
-stub packages. This will be validated via a PoC.
+**One concrete risk:** module resolution in the Bazel sandbox. Need to verify that both
+paths work: ty discovering pip deps via the venv layout, and first-party deps via
+`--extra-search-path`. This will be validated via a PoC.
 
 **Next step:** [Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2) — proof-of-concept
 to validate ty's module resolution in a Bazel sandbox with venvs_site_packages.

--- a/plans/issue1-kick-off.md
+++ b/plans/issue1-kick-off.md
@@ -80,7 +80,7 @@ Landed in:
 
 ----
 
-## Project structure
+## ✅ Project structure
 
 Proposed layout based on rules_mypy, simplified for ty:
 

--- a/plans/issue1-kick-off.md
+++ b/plans/issue1-kick-off.md
@@ -69,7 +69,14 @@ Landed in:
 - `design/reference.md` (section on rules_multitool)
 
 ----
-## How to update dependency versions
+## ✅ How to update dependency versions
+
+Captured the convention (keep deps current, no fixed cadence yet) and procedures (multitool CLI
+for ty binary, manual version bumps for MODULE.bazel, future renovate/dependabot automation).
+
+Landed in:
+- `design/conventions.md` (section 6 — dependency updates policy)
+- `design/reference.md` (section 4 — update procedures)
 
 ----
 

--- a/plans/issue1-kick-off.md
+++ b/plans/issue1-kick-off.md
@@ -1,0 +1,32 @@
+I want to kick off this project.
+
+Description is in: https://github.com/shayanhoshyari/rules_ty/issues/1
+
+Let's brainstorm together and plan to do this.
+
+---
+
+## ✅ AI native development
+
+Reviewed the AI-native setup from Adobe-Firefly/foundry/experimental/hoshyari/job_ui.
+Carried over the good parts (design/ → src/ sync contract, plans as decision logs) and
+fixed the issues (AGENTS.md as source of truth instead of CLAUDE.md, split conventions
+into a separate doc, keep AGENTS.md compact).
+
+Landed in:
+- `AGENTS.md` — project summary, sync contract, directory layout
+- `CLAUDE.md` — pointer to AGENTS.md
+- `design/conventions.md` — plan lifecycle, folder roles, coding standards
+
+Key decisions:
+- Tool-agnostic: AGENTS.md is the real content, CLAUDE.md just points to it.
+- No .gitattributes linguist-generated marking — want hands-on code review for this project.
+- No runtime context (unlike job_ui, this is a Bazel ruleset, not an MCP server).
+- Plans get frozen with a status header after implementation; design/ stays living.
+
+----
+
+## Other things to discuss one by one
+
+- Is it possible to achieve this in first place.
+- Project structure

--- a/plans/issue1-kick-off.md
+++ b/plans/issue1-kick-off.md
@@ -26,7 +26,52 @@ Key decisions:
 
 ----
 
+## Project structure
+
+Proposed layout based on rules_mypy, simplified for ty:
+
+```
+rules_ty/
+  MODULE.bazel              # Bazel module definition
+  BUILD.bazel
+  .bazelversion             # Pin Bazel 9.x
+  .bazelrc                  # Default flags
+  REPO.bazel                # ignore_directories() for non-Bazel dirs (plans/, design/, docs/, .worktrees/, etc.)
+
+  AGENTS.md / CLAUDE.md / plans/ / design/ / .worktrees/   # (established)
+
+  ty/
+    ty.bzl                  # Public API: ty() aspect factory
+    BUILD.bazel
+    private/
+      ty.bzl                # Aspect implementation
+      BUILD.bazel
+
+  examples/
+    basic/
+      MODULE.bazel
+      BUILD.bazel
+      ...
+
+  docs/                     # Sphinx / readthedocs
+  .bcr/                     # Bazel Central Registry metadata
+```
+
+Key simplifications vs rules_mypy:
+- No Python runner (ty is a standalone binary, not a Python library)
+- No `types.bzl` extension (rely on gazelle's `python_generate_pyi_deps`)
+- No WORKSPACE (Bazel 9+ only, bzlmod only)
+- No cache propagation (ty is fast enough to not need it)
+
+### Open questions
+
+- [ ] **ty toolchain:** How to resolve the ty binary? Options: (a) toolchain that downloads from GitHub releases per platform, (b) user provides it. Needs architecture discussion.
+- [ ] **`tools/` directory:** Do we need one for buildifier config, CI scripts, etc.?
+- [ ] **`examples/` scope:** Single basic example or multiple (basic, opt-in, custom-config)?
+- [ ] **CI from the start:** Set up `.github/workflows/` now or defer?
+
+----
+
 ## Other things to discuss one by one
 
 - Is it possible to achieve this in first place.
-- Project structure

--- a/plans/issue1-kick-off.md
+++ b/plans/issue1-kick-off.md
@@ -26,6 +26,53 @@ Key decisions:
 
 ----
 
+## ✅ How to resolve and run ty
+
+### Findings
+
+- ty is a standalone Rust binary (not a Python library). No `py_binary` wrapper needed.
+- ty publishes releases on GitHub: https://github.com/astral-sh/ty/releases
+- rules_uv uses `rules_multitool` to download uv — same pattern works for ty.
+
+### rules_multitool approach (from rules_uv)
+
+1. `MODULE.bazel`: `bazel_dep(name = "rules_multitool", ...)`, set up `multitool.hub()` with a lockfile.
+2. `ty/private/ty.lock.json`: per-platform URLs + SHAs pointing to ty's GitHub releases.
+3. Aspect references the binary as `attr.label(default = "@multitool//tools/ty", executable = True, cfg = "exec")`.
+
+The lockfile can be auto-updated via the `multitool` CLI.
+
+### Toolchain approach (rejected)
+
+A full Bazel toolchain (`ty_toolchain_type`, `ty_toolchain`, registration in MODULE.bazel) adds
+significant boilerplate for no real benefit. Toolchains are useful when you need per-target tool
+version selection — we don't. Every target uses the same ty.
+
+### exec vs target platform (transition_to_target)
+
+rules_uv has a `transition_to_target` hack ([PR #122](https://github.com/bazel-contrib/rules_uv/pull/122))
+because its `pip_compile` is a run rule (`executable = True`) — the shell script runs on the local
+machine (target platform), but `cfg = "exec"` downloads the binary for the exec platform. This is a
+mismatch in cross-compilation / remote execution scenarios.
+
+Not an issue for us: our ty aspect uses `ctx.actions.run()` — a proper build action that runs in
+the sandbox on the exec platform. `cfg = "exec"` is correct. No transition needed.
+
+The rules_uv maintainer also noted this is a design smell and suggested converting to build actions
+with `write_source_files` to copy output back to the source tree.
+
+### Decision
+
+Use `rules_multitool` with `cfg = "exec"`. No toolchain, no transition hack.
+
+Landed in:
+- `design/reference.md` (section on rules_multitool)
+
+----
+## How to update dependency versions
+
+----
+
 ## Project structure
 
 Proposed layout based on rules_mypy, simplified for ty:
@@ -65,7 +112,7 @@ Key simplifications vs rules_mypy:
 
 ### Open questions
 
-- [ ] **ty toolchain:** How to resolve the ty binary? Options: (a) toolchain that downloads from GitHub releases per platform, (b) user provides it. Needs architecture discussion.
+- [x] **ty resolution:** Resolved — use `rules_multitool` (see "How to resolve and run ty" section above).
 - [ ] **`tools/` directory:** Do we need one for buildifier config, CI scripts, etc.?
 - [ ] **`examples/` scope:** Single basic example or multiple (basic, opt-in, custom-config)?
 - [ ] **CI from the start:** Set up `.github/workflows/` now or defer?

--- a/plans/issue1-kick-off.md
+++ b/plans/issue1-kick-off.md
@@ -86,29 +86,37 @@ Proposed layout based on rules_mypy, simplified for ty:
 
 ```
 rules_ty/
-  MODULE.bazel              # Bazel module definition
-  BUILD.bazel
+  MODULE.bazel              # Bazel module definition + bazel_binaries extension for integration tests
+  BUILD.bazel               # filegroup "local_repository_files" for integration tests
   .bazelversion             # Pin Bazel 9.x
-  .bazelrc                  # Default flags
-  REPO.bazel                # ignore_directories() for non-Bazel dirs (plans/, design/, docs/, .worktrees/, etc.)
+  .bazelrc                  # Default flags + --deleted_packages for example child workspaces
+  REPO.bazel                # ignore_directories() for non-Bazel dirs (plans/, design/, docs/, .worktrees/)
 
   AGENTS.md / CLAUDE.md / plans/ / design/ / .worktrees/   # (established)
 
   ty/
     ty.bzl                  # Public API: ty() aspect factory
-    BUILD.bazel
+    BUILD.bazel             # includes filegroup "all_files" for integration tests
     private/
       ty.bzl                # Aspect implementation
+      ty.lock.json          # multitool lockfile for ty binary
       BUILD.bazel
 
   examples/
-    basic/
-      MODULE.bazel
-      BUILD.bazel
-      ...
+    BUILD.bazel             # bazel_integration_tests() targets + test_suite
+    simple/
+      MODULE.bazel          # local_path_override(module_name = "rules_ty", path = "../..")
+      BUILD.bazel           # Minimal: one py_library, shows basic usage
+    comprehensive/
+      MODULE.bazel          # local_path_override(module_name = "rules_ty", path = "../..")
+      BUILD.bazel           # Full coverage: cross-deps, third-party, generated files, etc.
+      ...                   # Adapted from rules_mypy demo (stripped: types ext, cache, opt-in)
 
   docs/                     # Sphinx / readthedocs
   .bcr/                     # Bazel Central Registry metadata
+  .github/
+    workflows/
+      ci.yml                # Runs bazel test //examples:all_integration_tests
 ```
 
 Key simplifications vs rules_mypy:
@@ -117,12 +125,40 @@ Key simplifications vs rules_mypy:
 - No WORKSPACE (Bazel 9+ only, bzlmod only)
 - No cache propagation (ty is fast enough to not need it)
 
-### Open questions
+### Decisions
 
-- [x] **ty resolution:** Resolved — use `rules_multitool` (see "How to resolve and run ty" section above).
-- [ ] **`tools/` directory:** Do we need one for buildifier config, CI scripts, etc.?
-- [ ] **`examples/` scope:** Single basic example or multiple (basic, opt-in, custom-config)?
-- [ ] **CI from the start:** Set up `.github/workflows/` now or defer?
+- [x] **ty resolution:** Use `rules_multitool` (see "How to resolve and run ty" section above).
+- [x] **Integration testing:** Use `rules_bazel_integration_test` to test examples against multiple
+      Bazel versions. Each example is an independent Bazel module with `local_path_override` pointing
+      to the parent. Tests are `bazel test` targets, runnable locally — not just in CI.
+- [x] **`examples/` scope:** Two examples: `examples/simple/` (minimal, human-friendly) and
+      `examples/comprehensive/` (full coverage, adapted from rules_mypy demo). No opt-in example —
+      we're always-on by default (see design/architecture.md section 1.1).
+- [x] **CI from the start:** Yes, minimal. Single workflow running
+      `bazel test //examples:all_integration_tests`.
+- [x] **All checks as `bazel test`:** buildifier format, `--deleted_packages` sync, integration
+      tests — all runnable via `bazel test //...`. No manual sanity checks.
+- [x] **`tools/` directory:** Not needed. `buildifier` comes from `buildifier_prebuilt` as a
+      `bazel_dep`. CI lives in `.github/workflows/`.
+
+### ignore_directories() vs --deleted_packages
+
+Two mechanisms for hiding directories from Bazel, used for different purposes:
+
+| Directory | Mechanism | Why |
+|-----------|-----------|-----|
+| `plans/`, `design/`, `docs/`, `.worktrees/` | `ignore_directories()` in REPO.bazel | Completely invisible to Bazel |
+| `examples/simple/`, `examples/comprehensive/`, etc. | `--deleted_packages` in .bazelrc | Removes child packages from parent, but files remain visible to `glob()` so integration tests can collect them |
+
+`ignore_directories()` makes files completely invisible — `glob()` can't see them.
+`--deleted_packages` removes packages but files are still glob-able — required by
+`rules_bazel_integration_test` which uses `glob_workspace_files()` from the parent.
+
+The integration test repo provides a tool to auto-populate deleted_packages:
+`bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
+
+Landed in:
+- `design/reference.md` (sections on ignore_directories, rules_bazel_integration_test)
 
 ----
 

--- a/plans/issue1-kick-off.md
+++ b/plans/issue1-kick-off.md
@@ -162,6 +162,26 @@ Landed in:
 
 ----
 
-## Other things to discuss one by one
+## ✅ Feasibility analysis
 
-- Is it possible to achieve this in first place.
+ty maps cleanly to the Bazel aspect pattern: `ty check [PATH...]` with `--extra-search-path`
+replaces mypy + MYPYPATH, `--python-version` can be inferred from the toolchain, typeshed is
+bundled, and ty's speed eliminates the need for cache propagation.
+
+All four issues from the GitHub issue are addressable:
+1. Remove `types` mapping → rely on gazelle's `python_generate_pyi_deps`
+2. Fix torch performance → ty is 10-100x faster
+3. Bazel 9 compat → starting fresh, Bazel 9+ only
+4. Remove `python_version` param → infer from Python toolchain
+
+**Key decision:** require `rules_python` `venvs_site_packages=yes`. This mode gives each
+`py_binary` a standard `.venv/site-packages/` layout, which ty natively discovers. This
+simplifies module resolution (no manual `--extra-search-path` per dep) and is future-looking
+(this is the direction rules_python is heading). See `design/architecture.md` §1.2.
+
+**One concrete risk:** module resolution in the Bazel sandbox. Need to verify that ty can
+use the venv layout provided by `venvs_site_packages` for first-party, third-party, and
+stub packages. This will be validated via a PoC.
+
+**Next step:** [Issue #2](https://github.com/shayanhoshyari/rules_ty/issues/2) — proof-of-concept
+to validate ty's module resolution in a Bazel sandbox with venvs_site_packages.


### PR DESCRIPTION
## Summary

Kick off the rules_ty project: establish AI-native development workflow, design docs, and all key architectural decisions.

- Set up AGENTS.md, CLAUDE.md, design/ (conventions, architecture, reference), and plans/
- Decide on rules_multitool for ty binary resolution (no toolchain, no transition hack)
- Decide on venvs_site_packages requirement with two-path module resolution strategy
- Define project structure with integration testing via rules_bazel_integration_test
- Capture feasibility analysis with PoC benchmark scenarios and success criteria
- Document dependency update conventions and procedures

Closes #1

## What's NOT in this PR

- No source code yet — this is planning and design only
- Sphinx/readthedocs setup deferred to #3
- PoC for module resolution deferred to #2
