### PR TITLE
Add README and document its role

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Full details in [design/conventions.md](design/conventions.md) (section 4).
 
 ```
 rules_ty/
+  README.md              ← Public landing page (status, links, usage once available)
   AGENTS.md              ← You are here. Workflow and pointers.
   plans/                 ← Proposals and ideations (frozen after implementation)
   design/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# rules_ty
+
+Bazel rules for [ty](https://docs.astral.sh/ty/), the fast Python type checker by Astral.
+
+Similar to [rules_mypy](https://github.com/bazel-contrib/rules_mypy) but targeting ty, Bazel 9+, and fixing known pain points:
+
+- No `types` mapping — rely on [gazelle](https://rules-python.readthedocs.io/en/latest/gazelle/docs/directives.html#python-generate-pyi-deps) instead
+- No per-target cache propagation — ty is fast enough
+- No `python_version` parameter — inferred from the Python toolchain
+- Requires [`venvs_site_packages`](https://rules-python.readthedocs.io/en/stable/api/rules_python/python/config_settings/index.html) for third-party module resolution
+
+## Status
+
+**Under development — design phase. No usable rules yet.**
+
+- [x] Project kick-off and architectural decisions ([#1](https://github.com/shayanhoshyari/rules_ty/issues/1))
+- [ ] PoC: validate ty's module resolution in a Bazel sandbox ([#2](https://github.com/shayanhoshyari/rules_ty/issues/2))
+- [ ] Sphinx / readthedocs documentation ([#3](https://github.com/shayanhoshyari/rules_ty/issues/3))

--- a/design/conventions.md
+++ b/design/conventions.md
@@ -10,6 +10,7 @@
 
 | Folder | Role | Mutability |
 |--------|------|------------|
+| `README.md` | Public landing page: project summary, status, usage (once available) | Updated as milestones land |
 | `plans/` | Proposals, ideations, brainstorming | Frozen after implementation |
 | `design/` | Living specs — architecture, conventions, reference | Updated as the project evolves |
 | `ty/` | Bazel rules source code | Derived from `design/` |


### PR DESCRIPTION
Minimal README with project description, status tracker, and key links. Adds README to AGENTS.md directory layout and conventions.md folder roles so agents keep it updated.

Made with [Cursor](https://cursor.com)